### PR TITLE
Fix bug in wasm2c's tail-call optimization code generation

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1858,7 +1858,7 @@ void CWriter::WriteTailCallWeakImports() {
     Index num_results = func.GetNumResults();
     if (num_params >= 1) {
       Write(func.decl.sig.param_types, " params;", Newline());
-      Write("wasm_rt_memcpy(params, tail_call_stack, sizeof(params);",
+      Write("wasm_rt_memcpy(params, tail_call_stack, sizeof(params));",
             Newline());
     }
 


### PR DESCRIPTION
When generating code with wasm2c and tail call optimizations enabled, invalid calls to `wasm_rt_memcpy` are generated.